### PR TITLE
[UTILITY] : Celsius to Fahrenheit converter

### DIFF
--- a/src/temperature_converter.kin
+++ b/src/temperature_converter.kin
@@ -1,0 +1,24 @@
+# Function to convert Celsius to Fahrenheit
+porogaramu_ntoya celsius_to_fahrenheit(celsius) {
+    tanga (celsius * 9/5) + 32
+}
+
+# Function to convert Fahrenheit to Celsius
+porogaramu_ntoya fahrenheit_to_celsius(fahrenheit) {
+    tanga (fahrenheit - 32) * 5/9
+}
+
+# Ask the user for the temperature and the conversion type
+reka temperature = injiza_amakuru("Injiza ubushyuhe: ")
+reka conversion_type = injiza_amakuru("Hitamo ubwoko bw'ihinduranya (C2F/F2C): ")
+
+# Perform the conversion based on the user's choice
+niba (conversion_type == "C2F") {
+    reka result = celsius_to_fahrenheit(temperature)
+    tangaza_amakuru(temperature, " degrees Celsius ni ", result, " degrees Fahrenheit.")
+} nanone_niba (conversion_type == "F2C") {
+    reka result = fahrenheit_to_celsius(temperature)
+    tangaza_amakuru(temperature, " degrees Fahrenheit ni ", result, " degrees Celsius.")
+} niba_byanze {
+    tangaza_amakuru("Hitamo ubwoko bw'ihinduranya butazwi.")
+}


### PR DESCRIPTION
celsius_to_fahrenheit: This function takes a temperature in Celsius and converts it to Fahrenheit.

fahrenheit_to_celsius: This function takes a temperature in Fahrenheit and converts it to Celsius.

User Input: The user is asked to enter a temperature and choose the conversion type (C2F for Celsius to Fahrenheit, F2C for Fahrenheit to Celsius).

Conversion and Output: Based on the user's choice, the appropriate conversion is performed, and the result is displayed.

This will help users to convert temperatures between celsius ad fahrenheit